### PR TITLE
Dev: Remove the condition.

### DIFF
--- a/src/Orchestration/Orchestrator.php
+++ b/src/Orchestration/Orchestrator.php
@@ -180,9 +180,6 @@ abstract class Orchestrator implements OrchestratorInterface
     {
         foreach ($this->steps as $step) {
             if (!$step->aliasNonRepeat($alias)) {
-                if ($step->getStepAction($alias)->getMeaningData() === null) {
-                    throw OrchestratorException::forStepActionMeaningDataIsNull($alias);
-                }
                 return $step->getStepAction($alias);
             }
         }


### PR DESCRIPTION
**Description**
Remove the orchestrator condition of judge whether the `getMeaningData` is null.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide
