### PR TITLE
Dev : Append the native php redis handler to cache.

### DIFF
--- a/develop/app/Anser/Orchestrators/v2/CreateOrderOrchestrator.php
+++ b/develop/app/Anser/Orchestrators/v2/CreateOrderOrchestrator.php
@@ -11,6 +11,7 @@ use Exception;
 use SDPMlab\Anser\Orchestration\OrchestratorInterface;
 use SDPMlab\Anser\Orchestration\Saga\Cache\CacheFactory;
 use SDPMlab\Anser\Orchestration\Saga\Cache\Redis\Config;
+use SDPMlab\Anser\Orchestration\Saga\Cache\NativeRedis\Config as NativeRedisConfig;
 
 class CreateOrderOrchestrator extends Orchestrator
 {
@@ -84,6 +85,8 @@ class CreateOrderOrchestrator extends Orchestrator
      */
     public $payment_key = null;
 
+    protected bool $useBackup = true;
+
     public function __construct()
     {
         $this->productService = new ProductService();
@@ -101,14 +104,22 @@ class CreateOrderOrchestrator extends Orchestrator
         $this->product_amount = $product_amount;
         $this->product_key    = $product_key;
 
-        $cache = CacheFactory::initCacheDriver('predis', new Config(
+        // Driver for predis
+        // $cache = CacheFactory::initCacheDriver(CacheFactory::CACHE_DRIVER_PREDIS, new Config(
+        //     host: "anser_redis",
+        //     port: 6379,
+        //     db: 1,
+        //     serverName: 'Anser_Server_1'
+        // ));
+
+        // Driver for phpredis
+        CacheFactory::initCacheDriver(CacheFactory::CACHE_DRIVER_NATIVE_REDIS, new NativeRedisConfig(
             host: "anser_redis",
             port: 6379,
             db: 1,
+            useDefaultConnection:true,
             serverName: 'Anser_Server_1'
         ));
-
-        // $this->setServerName("Anser_Server_1");
 
         // Step 1. Check the product inventory balance.
         $step1 = $this->setStep()->addAction(
@@ -129,6 +140,7 @@ class CreateOrderOrchestrator extends Orchestrator
             $user_key,
             $product_amount
         ) {
+            // exit;
             $product_data = $runtimeOrch->getStepAction("get_product_info")->getMeaningData();
             $total        = $product_data["price"] * $product_amount;
 

--- a/develop/app/Anser/Orchestrators/v2/CreateOrderOrchestrator.php
+++ b/develop/app/Anser/Orchestrators/v2/CreateOrderOrchestrator.php
@@ -10,6 +10,7 @@ use App\Anser\Services\V2\OrderService;
 use Exception;
 use SDPMlab\Anser\Orchestration\OrchestratorInterface;
 use SDPMlab\Anser\Orchestration\Saga\Cache\CacheFactory;
+use SDPMlab\Anser\Orchestration\Saga\Cache\Redis\Config;
 
 class CreateOrderOrchestrator extends Orchestrator
 {
@@ -100,9 +101,14 @@ class CreateOrderOrchestrator extends Orchestrator
         $this->product_amount = $product_amount;
         $this->product_key    = $product_key;
 
-        $cache = CacheFactory::initCacheDriver('redis', 'tcp://anser_redis:6379');
+        $cache = CacheFactory::initCacheDriver('predis', new Config(
+            host: "anser_redis",
+            port: 6379,
+            db: 1,
+            serverName: 'Anser_Server_1'
+        ));
 
-        $this->setServerName("Anser_Server_1");
+        // $this->setServerName("Anser_Server_1");
 
         // Step 1. Check the product inventory balance.
         $step1 = $this->setStep()->addAction(

--- a/develop/app/Controllers/v2/CreateOrderRestarter.php
+++ b/develop/app/Controllers/v2/CreateOrderRestarter.php
@@ -7,6 +7,7 @@ use App\Controllers\BaseController;
 use CodeIgniter\API\ResponseTrait;
 use SDPMlab\Anser\Orchestration\Saga\Restarter\Restarter;
 use SDPMlab\Anser\Orchestration\Saga\Cache\CacheFactory;
+use SDPMlab\Anser\Orchestration\Saga\Cache\NativeRedis\Config as NativeRedisConfig;
 
 class CreateOrderRestarter extends BaseController
 {
@@ -14,11 +15,19 @@ class CreateOrderRestarter extends BaseController
 
     public function restartCreateOrderOrchestratorByServerName()
     {
-        CacheFactory::initCacheDriver('redis', 'tcp://anser_redis:6379');
+        // CacheFactory::initCacheDriver('redis', 'tcp://anser_redis:6379');
+
+        CacheFactory::initCacheDriver(CacheFactory::CACHE_DRIVER_NATIVE_REDIS, new NativeRedisConfig(
+            host: "anser_redis",
+            port: 6379,
+            db: 1,
+            useDefaultConnection:true,
+            serverName: 'Anser_Server_1'
+        ));
 
         $userOrchRestarter = new Restarter();
 
-        $result = $userOrchRestarter->reStartOrchestratorsByServer(CreateOrderOrchestrator::class, 'Anser_Server_1');
+        $result = $userOrchRestarter->reStartOrchestratorsByServer(CreateOrderOrchestrator::class, 'Anser_Server_1',true);
 
         return $this->respond([
             "result" => $result
@@ -27,8 +36,8 @@ class CreateOrderRestarter extends BaseController
 
     public function restartCreateOrderOrchestratorByServerCluster()
     {
-        CacheFactory::initCacheDriver('redis', 'tcp://anser_redis:6379');
-
+        // CacheFactory::initCacheDriver('redis', 'tcp://anser_redis:6379');
+        
         $userOrchRestarter = new Restarter();
 
         $result = $userOrchRestarter->reStartOrchestratorsByServer(
@@ -43,7 +52,15 @@ class CreateOrderRestarter extends BaseController
 
     public function restartCreateOrderOrchestratorByClassName()
     {
-        CacheFactory::initCacheDriver('redis', 'tcp://anser_redis:6379');
+        // CacheFactory::initCacheDriver('redis', 'tcp://anser_redis:6379');
+
+        CacheFactory::initCacheDriver(CacheFactory::CACHE_DRIVER_NATIVE_REDIS, new NativeRedisConfig(
+            host: "anser_redis",
+            port: 6379,
+            db: 1,
+            useDefaultConnection:true,
+            serverName: 'Anser_Server_1'
+        ));
 
         $userOrchRestarter = new Restarter();
 

--- a/develop/composer.lock
+++ b/develop/composer.lock
@@ -3410,16 +3410,16 @@
         },
         {
             "name": "zumba/json-serializer",
-            "version": "3.0.2",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zumba/json-serializer.git",
-                "reference": "421dcdd53d4b333303d984e9ebec557d3e37783b"
+                "reference": "93786164efd20b6e01d42b03d4f7c2e52c9cebd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zumba/json-serializer/zipball/421dcdd53d4b333303d984e9ebec557d3e37783b",
-                "reference": "421dcdd53d4b333303d984e9ebec557d3e37783b",
+                "url": "https://api.github.com/repos/zumba/json-serializer/zipball/93786164efd20b6e01d42b03d4f7c2e52c9cebd8",
+                "reference": "93786164efd20b6e01d42b03d4f7c2e52c9cebd8",
                 "shasum": ""
             },
             "require": {
@@ -3427,10 +3427,10 @@
                 "php": "^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=6.0 <10.0"
+                "phpunit/phpunit": ">=6.0 <11.0"
             },
             "suggest": {
-                "jeremeamia/superclosure": "Allow to serialize PHP closures"
+                "opis/closure": "Allow to serialize PHP closures"
             },
             "type": "library",
             "autoload": {
@@ -3454,7 +3454,7 @@
                 }
             ],
             "description": "Serialize PHP variables, including objects, in JSON format. Support to unserialize it too.",
-            "homepage": "http://tech.zumba.com",
+            "homepage": "https://tech.zumba.com",
             "keywords": [
                 "json",
                 "serialize",
@@ -3462,9 +3462,9 @@
             ],
             "support": {
                 "issues": "https://github.com/zumba/json-serializer/issues",
-                "source": "https://github.com/zumba/json-serializer/tree/3.0.2"
+                "source": "https://github.com/zumba/json-serializer/tree/3.2.0"
             },
-            "time": "2022-12-07T14:14:45+00:00"
+            "time": "2023-09-25T19:48:23+00:00"
         }
     ],
     "packages-dev": [

--- a/develop/tests/Anser/Orchestration/Saga/Cache/Redis/NativeRedisHandlerTest.php
+++ b/develop/tests/Anser/Orchestration/Saga/Cache/Redis/NativeRedisHandlerTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace SDPMlab\Anser\Service;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use SDPMlab\Anser\Orchestration\Saga\Cache\NativeRedis\NativeRedisHandler;
+use SDPMlab\Anser\Orchestration\Saga\Cache\NativeRedis\config as NativeRedisConfig;
+use SDPMlab\Anser\Exception\RedisException;
+use SDPMlab\Anser\Orchestration\Orchestrator;
+use SDPMlab\Anser\Orchestration\Saga\Cache\CacheFactory;
+
+class TestOrchestratorForNative extends Orchestrator
+{
+    protected function definition()
+    {
+    }
+}
+
+class NativeRedisHandlerTest extends CIUnitTestCase
+{
+
+    /**
+     * cacheInstance
+     *
+     * @var SDPMlab\Anser\Orchestration\Saga\Cache\NativeRedis\NativeRedisHandler
+     */
+    protected $cache;
+
+    /**
+     * The cache client (native php redis)
+     *
+     * @var \Redis;
+     */
+    protected \Redis $cacheClient;
+
+    protected function setUp(): void
+    {
+        $this->cache  = CacheFactory::initCacheDriver(
+            CacheFactory::CACHE_DRIVER_NATIVE_REDIS, 
+            new NativeRedisConfig(
+                host: "anser_redis",
+                port: 6379,
+                db: 1,
+                useDefaultConnection:true,
+                serverName: 'server_1'
+        ));
+
+        $this->cacheClient = new \Redis();
+        $this->cacheClient->connect(
+            'anser_redis',
+            6379,
+            0
+        );
+        $this->cacheClient->select(1);
+
+        putenv("serverName_1=server_1");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cacheClient->flushall();
+    }
+
+    public function testInitOrchestrator()
+    {
+        $runTimeOrch = new TestOrchestratorForNative();
+        $runTimeOrch->build();
+
+        $this->cache->initOrchestrator($runTimeOrch);
+
+        // Check whether the serialized runtime orch is in serverName hashMap.
+        $this->assertEquals(
+            $this->cache->serializeOrchestrator($runTimeOrch),
+            $this->cacheClient->hget(
+                getenv("serverName_1"),
+                $runTimeOrch->getOrchestratorNumber()
+            )
+        );
+
+        // Check whether the serverName is in serverNameList set.
+        $this->assertEquals(1, $this->cacheClient->sismember("serverNameList", getenv("serverName_1")));
+
+        // // Check the repeat orch number.
+        $this->expectException(RedisException::class);
+        $this->expectExceptionMessage("此編排器編號- {$runTimeOrch->getOrchestratorNumber()} 已在 Redis 內被初始化，請重新輸入。");
+        $this->cache->initOrchestrator($runTimeOrch);
+    }
+
+    public function testSetOrchestrator()
+    {
+        $orchestrator = new TestOrchestratorForNative();
+        $orchestrator->build();
+
+        $this->cache->initOrchestrator($orchestrator);
+
+        // Something change in runtime orch.
+        $orchestrator->setServerName(getenv("serverName_1"));
+
+        $this->cache->setOrchestrator($orchestrator);
+
+        $this->assertEquals(
+            $this->cache->serializeOrchestrator($orchestrator),
+            $this->cacheClient->hget(getenv("serverName_1"), $orchestrator->getOrchestratorNumber())
+        );
+    }
+
+    public function testGetOrchestrator()
+    {
+        $orchestrator = new TestOrchestratorForNative();
+        $orchestrator->build();
+        
+        $this->cache->initOrchestrator($orchestrator);
+
+        $runtimeOrch = $this->cache->getOrchestrator(
+            $orchestrator->getOrchestratorNumber()
+        );
+
+        $this->assertEquals($runtimeOrch, $orchestrator);
+    }
+
+    public function testGetOrchestrators()
+    {
+        $orchestrator = new TestOrchestratorForNative();
+        $orchestrator->build();
+        
+        $this->cache->initOrchestrator($orchestrator);
+
+        $runtimeOrch = $this->cache->getOrchestrators(TestOrchestratorForNative::class, getenv("serverName_1"));
+
+        $this->assertEquals($runtimeOrch[$orchestrator->getOrchestratorNumber()], $orchestrator);
+    }
+
+    public function testGetOrchestratorsByClassName()
+    {
+        $orchestrator = new TestOrchestratorForNative();
+        $orchestrator->build();
+        
+        $this->cache->initOrchestrator($orchestrator);
+
+        $runtimeOrch = $this->cache->getOrchestrators(TestOrchestratorForNative::class);
+
+        $this->assertEquals($runtimeOrch[$orchestrator->getOrchestratorNumber()], $orchestrator);
+    }
+
+    public function testGetServersOrchestrator()
+    {
+        $orchestrator = new TestOrchestratorForNative();
+        $orchestrator->build();
+
+        $this->cache->initOrchestrator($orchestrator);
+
+        $runtimeOrch = $this->cache->getServersOrchestrator(TestOrchestratorForNative::class);
+
+        $this->assertEquals(
+            $runtimeOrch[getenv("serverName_1")][$orchestrator->getOrchestratorNumber()], 
+            $orchestrator
+        );
+    }
+    
+    public function testClearOrchestrator()
+    {
+        $orchestrator = new TestOrchestratorForNative();
+        $orchestrator->build();
+
+        $this->cache->initOrchestrator($orchestrator);
+
+        $this->cache->clearOrchestrator($orchestrator);
+
+        $this->assertEquals(
+            0,
+            $this->cacheClient->hget(
+                getenv("serverName_1"),
+                $orchestrator->getOrchestratorNumber()
+            )
+        );
+
+        $this->assertEquals(
+            0,
+            $this->cacheClient->sismember("serverNameList", getenv("serverName_1"))
+        );
+    }
+}

--- a/develop/tests/Anser/Orchestration/Saga/Cache/Redis/NativeRedisHandlerTest.php
+++ b/develop/tests/Anser/Orchestration/Saga/Cache/Redis/NativeRedisHandlerTest.php
@@ -118,6 +118,15 @@ class NativeRedisHandlerTest extends CIUnitTestCase
         $this->assertEquals($runtimeOrch, $orchestrator);
     }
 
+    public function testGetOrchestratorNotFound()
+    {
+        $notExistOrchNum = TestOrchestratorForNative::class . '\\' . md5(json_encode(["foo" => "bar", "bar" => "baz"]) . uniqid("", true)) . '\\' . date("Y-m-d H:i:s");
+
+        $this->expectException(RedisException::class);
+        $this->expectExceptionMessage("Redis 內找不到此編排器編號- {$notExistOrchNum} ，請重新輸入。");
+        $this->cache->getOrchestrator($notExistOrchNum);
+    }
+
     public function testGetOrchestrators()
     {
         $orchestrator = new TestOrchestratorForNative();
@@ -178,5 +187,21 @@ class NativeRedisHandlerTest extends CIUnitTestCase
             0,
             $this->cacheClient->sismember("serverNameList", getenv("serverName_1"))
         );
+    }
+
+    public function testClearOrchestratorNotFound()
+    {
+        $orchestrator = new TestOrchestratorForNative();
+        $orchestrator->build();
+
+        $this->cache->initOrchestrator($orchestrator);
+        $this->cacheClient->hdel(
+            getenv("serverName_1"),
+            $orchestrator->getOrchestratorNumber()
+        );
+
+        $this->expectException(RedisException::class);
+        $this->expectExceptionMessage("Redis 內找不到此編排器編號- {$orchestrator->getOrchestratorNumber()} ，請重新輸入。");
+        $this->cache->clearOrchestrator($orchestrator);
     }
 }

--- a/src/Exception/RedisException.php
+++ b/src/Exception/RedisException.php
@@ -50,4 +50,9 @@ class RedisException extends AnserException
     {
         return new self("ClassName 尚未被設定，請傳入 className 參數。");
     }
+
+    public static function forRedisExtensionNotExist(): RedisException
+    {
+        return new self("未安裝 Redis 擴展，請檢查是否安裝。");
+    }
 }

--- a/src/Orchestration/Saga/Cache/CacheFactory.php
+++ b/src/Orchestration/Saga/Cache/CacheFactory.php
@@ -3,12 +3,14 @@
 namespace SDPMlab\Anser\Orchestration\Saga\Cache;
 
 use SDPMlab\Anser\Orchestration\Saga\Cache\Redis\PRedisHandler;
+use SDPMlab\Anser\Orchestration\Saga\Cache\NativeRedis\NativeRedisHandler;
 use SDPMlab\Anser\Orchestration\Saga\Cache\CacheHandlerInterface;
 use SDPMlab\Anser\Exception\RedisException;
 
 class CacheFactory
 {
     const CACHE_DRIVER_PREDIS = "predis";
+    const CACHE_DRIVER_NATIVE_REDIS = "nativeredis";
 
     /**
      * The mapping list of Cache Drivers instance.
@@ -16,7 +18,8 @@ class CacheFactory
      * @var array
      */
     private static $cacheMapping = [
-        "predis" => PRedisHandler::class,
+        "predis"      => PRedisHandler::class,
+        "nativeredis" => NativeRedisHandler::class
     ];
 
     /**

--- a/src/Orchestration/Saga/Cache/NativeRedis/Config.php
+++ b/src/Orchestration/Saga/Cache/NativeRedis/Config.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SDPMlab\Anser\Orchestration\Saga\Cache\NativeRedis;
+
+class config
+{
+    /**
+     * The scheme of Redis.
+     *
+     * @var string
+     */
+    public $scheme = 'tcp';
+
+    /**
+     * The host of Redis.
+     *
+     * @var string
+     */
+    public $host = '127.0.0.1';
+
+    /**
+     * The port of Redis.
+     *
+     * @var integer
+     */
+    public $port = 6379;
+
+    /**
+     * The timeout of Redis.
+     *
+     * @var integer|float
+     */
+    public $timeout = 0;
+
+    /**
+     * The db of Redis.
+     *
+     * @var integer
+     */
+    public $db = 0;
+
+    /**
+     * The connection type of Redis e.g. connect(), pconnect()
+     * Default is connect()
+     *
+     * @var boolean
+     */
+    public $useDefaultConnection = false;
+
+    /**
+     * The serverName as the hashmap key.
+     * You can set this value to identify the server.
+     *
+     * @var string
+     */
+    public $serverName = 'AnserServer';
+
+    public function __construct(
+        string $scheme = 'tcp',
+        string $host = 'localhost',
+        int $port = 6379,
+        int $timeout = 0,
+        int $db = 0,
+        bool $useDefaultConnection = false,
+        string $serverName = 'AnserServer'
+    ) {
+        $this->scheme  = $scheme;
+        $this->host    = $host;
+        $this->port    = $port;
+        $this->timeout = $timeout;
+        $this->db      = $db;
+        $this->useDefaultConnection = $useDefaultConnection;
+        $this->serverName = $serverName;
+    }
+
+    public function __sleep()
+    {
+        return ['scheme', 'host', 'port', 'timeout', 'db', 'useDefaultConnection', 'serverName'];
+    }
+}

--- a/src/Orchestration/Saga/Cache/NativeRedis/NativeRedisHandler.php
+++ b/src/Orchestration/Saga/Cache/NativeRedis/NativeRedisHandler.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace SDPMlab\Anser\Orchestration\Saga\Cache\NativeRedis;
+
+use App\Controllers\V1\Redis;
+use SDPMlab\Anser\Orchestration\Saga\Cache\BaseCacheHandler;
+use SDPMlab\Anser\Orchestration\Saga\Cache\CacheHandlerInterface;
+use SDPMlab\Anser\Orchestration\Saga\Cache\NativeRedis\Config;
+use SDPMlab\Anser\Orchestration\OrchestratorInterface;
+use SDPMlab\Anser\Exception\RedisException;
+
+class NativeRedisHandler extends BaseCacheHandler
+{
+    protected Config $config;
+
+    protected $option = [];
+
+    /**
+     * The client of Redis.
+     *
+     * @var client
+     */
+    protected $client;
+
+    public function __construct(Config $config = null, ?array $option = null)
+    {
+        parent::__construct();
+
+        if (!extension_loaded('redis')) {
+            throw RedisException::forRedisExtensionNotExist();
+        }
+
+        $this->config = $config;
+        $this->option = $option;
+       
+        try {
+            $this->client = new \Redis();
+
+            if ($this->config->useDefaultConnection) {
+                $this->client->pconnect(
+                    $this->config->host,
+                    $this->config->port,
+                    (int) $this->config->timeout
+                );
+            }else{
+                $this->client->connect(
+                    $this->config->host,
+                    $this->config->port,
+                    (int) $this->config->timeout
+                );
+            }
+
+            $this->client->select($this->config->db);
+        } catch (\RedisException $e) {
+            throw new \RedisException($e->getMessage());
+        }
+    }
+
+    public function __destruct()
+    {
+        $this->client->close();
+    }
+
+    public function __sleep()
+    {
+        $this->client->close();
+        return ['config', 'option', 'path'];
+    }
+
+    public function __wakeup()
+    {
+        $this->client = new \Redis();
+
+        if ($this->config->useDefaultConnection) {
+            $this->client->pconnect(
+                $this->config->host,
+                $this->config->port,
+                (int) $this->config->timeout
+            );
+        }else{
+            $this->client->connect(
+                $this->config->host,
+                $this->config->port,
+                (int) $this->config->timeout
+            );
+        }
+        $this->client->select($this->config->db);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initOrchestrator(OrchestratorInterface $runtimeOrchestrator): CacheHandlerInterface
+    {
+        $orchestratorNumber = $runtimeOrchestrator->getOrchestratorNumber();
+        $serverName         = $this->config->serverName;
+
+        if ($this->client->hexists($serverName, $orchestratorNumber)) {
+            throw RedisException::forCacheRepeatOrch($orchestratorNumber);
+        }
+
+        $serializedOrchestrator = $this->serializeOrchestrator($runtimeOrchestrator);
+
+        // If the serverName isn't exist in hashmap, add it to serverNameList set.
+        if (empty($this->client->hgetall($serverName))) {
+            $this->client->sadd("serverNameList", $serverName);
+        }
+
+        // Set orchNumber and serialized runtimeOrch in the serverName hashmap.
+        $this->client->hset($serverName, $orchestratorNumber, $serializedOrchestrator);
+        
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setOrchestrator(OrchestratorInterface $runtimeOrchestrator): CacheHandlerInterface
+    {
+        $this->client->hset(
+            $this->config->serverName,
+            $runtimeOrchestrator->getOrchestratorNumber(),
+            $this->serializeOrchestrator($runtimeOrchestrator)
+        );
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOrchestrator(string $orchestratorNumber = null): OrchestratorInterface
+    {
+        if (is_null($this->client->hget($this->config->serverName, $orchestratorNumber))) {
+            throw RedisException::forCacheOrchestratorNumberNotFound($orchestratorNumber);
+        }
+
+        $runtimeOrchestrator = $this->unserializeOrchestrator(
+            $this->client->hget($this->config->serverName, $orchestratorNumber)
+        );
+
+        return $runtimeOrchestrator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOrchestrators(string $className, ?string $serverName = null): ?array
+    {
+        if($serverName === null){
+            $serverName = $this->config->serverName;
+        }
+
+        // Get all serverName hashmap keys.
+        $keys = $this->client->hkeys($serverName);
+
+        if (empty($keys)) {
+            return null;
+        }
+
+        // Using the regular to filter the className.
+        $pattern = '/^' . preg_quote($className, '/') . '/';
+
+        $filteredData = preg_grep($pattern, $keys);
+
+        $orchestratorData = [];
+
+        // Put the filtered key and it's value in the array.
+        foreach ($filteredData as $key => $orchestratorNumber) {
+            $orchestratorData[$orchestratorNumber] = $this->unserializeOrchestrator(
+                $this->client->hget($serverName, $orchestratorNumber)
+            );
+        }
+
+        return $orchestratorData;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getServersOrchestrator(string $className): ?array
+    {
+        // Get all of serverName in Redis.
+        $serverNameList = $this->client->smembers("serverNameList");
+
+        if (empty($serverNameList)) {
+            return null;
+        }
+
+        $serverOrchestratorData = [];
+
+        foreach ($serverNameList as $key => $serverName) {
+            $serverOrchestratorData[$serverName] = $this->getOrchestrators($className, $serverName);
+        }
+
+        return $serverOrchestratorData;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearOrchestrator(OrchestratorInterface $runtimeOrchestrator): bool
+    {
+        $orchestratorNumber = $runtimeOrchestrator->getOrchestratorNumber();
+        if (is_null($this->client->hget($this->config->serverName, $orchestratorNumber))) {
+            throw RedisException::forCacheOrchestratorNumberNotFound($orchestratorNumber);
+        }
+
+        // Delete the orch number in hashmap.
+        $result = ($this->client->hdel($this->config->serverName, $orchestratorNumber)) == 1;
+
+        // If the $serverName hashmap is empty after delete orch, remove the $serverName from serverNameList.
+        if ($result === true && empty($this->client->hgetall($this->config->serverName))) {
+            $this->client->srem("serverNameList", $this->config->serverName);
+        }
+
+        return $result;
+    }
+
+}

--- a/src/Orchestration/Saga/Cache/NativeRedis/NativeRedisHandler.php
+++ b/src/Orchestration/Saga/Cache/NativeRedis/NativeRedisHandler.php
@@ -131,7 +131,7 @@ class NativeRedisHandler extends BaseCacheHandler
      */
     public function getOrchestrator(string $orchestratorNumber = null): OrchestratorInterface
     {
-        if (is_null($this->client->hget($this->config->serverName, $orchestratorNumber))) {
+        if (!$this->client->hexists($this->config->serverName, $orchestratorNumber)) {
             throw RedisException::forCacheOrchestratorNumberNotFound($orchestratorNumber);
         }
 
@@ -202,7 +202,8 @@ class NativeRedisHandler extends BaseCacheHandler
     public function clearOrchestrator(OrchestratorInterface $runtimeOrchestrator): bool
     {
         $orchestratorNumber = $runtimeOrchestrator->getOrchestratorNumber();
-        if (is_null($this->client->hget($this->config->serverName, $orchestratorNumber))) {
+
+        if (!$this->client->hexists($this->config->serverName, $orchestratorNumber)) {
             throw RedisException::forCacheOrchestratorNumberNotFound($orchestratorNumber);
         }
 


### PR DESCRIPTION
**Description**
Changed scope: 
1. Append the native php redis handler to cache.
2. Update the library of `zumba/json-serializer` at develop folder.
3. Append testing  for `NativeRedis` class.
4. Modified some logic at  `develop/app/Anser/Orchestrators/v2/CreateOrderOrchestrator.php` and `develop/app/Controllers/v2/CreateOrderRestarter.php`.




**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide